### PR TITLE
Update various modules to support python 3.13

### DIFF
--- a/cgi/cgi/__init__.py
+++ b/cgi/cgi/__init__.py
@@ -54,7 +54,9 @@ __all__ = ["MiniFieldStorage", "FieldStorage", "parse", "parse_multipart",
            "print_environ_usage"]
 
 
-warnings._deprecated(__name__, remove=(3,13))
+# python-deadlib: Remove deprecation warning
+# # python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 # Logging support
 # ===============

--- a/cgi/cgi/__init__.py
+++ b/cgi/cgi/__init__.py
@@ -55,8 +55,8 @@ __all__ = ["MiniFieldStorage", "FieldStorage", "parse", "parse_multipart",
 
 
 # python-deadlib: Remove deprecation warning
-# # python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# # python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 # Logging support
 # ===============

--- a/cgitb/cgitb/__init__.py
+++ b/cgitb/cgitb/__init__.py
@@ -34,8 +34,8 @@ import traceback
 import warnings
 from html import escape as html_escape
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 
 def reset():

--- a/cgitb/cgitb/__init__.py
+++ b/cgitb/cgitb/__init__.py
@@ -34,7 +34,8 @@ import traceback
 import warnings
 from html import escape as html_escape
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 
 def reset():

--- a/chunk/chunk/__init__.py
+++ b/chunk/chunk/__init__.py
@@ -50,8 +50,8 @@ default is 1, i.e. aligned.
 
 import warnings
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 class Chunk:
     def __init__(self, file, align=True, bigendian=True, inclheader=False):

--- a/chunk/chunk/__init__.py
+++ b/chunk/chunk/__init__.py
@@ -50,7 +50,8 @@ default is 1, i.e. aligned.
 
 import warnings
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 class Chunk:
     def __init__(self, file, align=True, bigendian=True, inclheader=False):

--- a/nntplib/nntplib/__init__.py
+++ b/nntplib/nntplib/__init__.py
@@ -86,7 +86,8 @@ __all__ = ["NNTP",
            "decode_header",
            ]
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 # maximal line length when calling readline(). This is to prevent
 # reading arbitrary length lines. RFC 3977 limits NNTP line length to

--- a/nntplib/nntplib/__init__.py
+++ b/nntplib/nntplib/__init__.py
@@ -86,8 +86,8 @@ __all__ = ["NNTP",
            "decode_header",
            ]
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 # maximal line length when calling readline(). This is to prevent
 # reading arbitrary length lines. RFC 3977 limits NNTP line length to

--- a/pipes/pipes/__init__.py
+++ b/pipes/pipes/__init__.py
@@ -65,8 +65,8 @@ import warnings
 # (quote used to be an undocumented but used function in pipes)
 from shlex import quote
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 __all__ = ["Template"]
 

--- a/pipes/pipes/__init__.py
+++ b/pipes/pipes/__init__.py
@@ -65,7 +65,8 @@ import warnings
 # (quote used to be an undocumented but used function in pipes)
 from shlex import quote
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 __all__ = ["Template"]
 

--- a/telnetlib/telnetlib/__init__.py
+++ b/telnetlib/telnetlib/__init__.py
@@ -39,8 +39,8 @@ import selectors
 from time import monotonic as _time
 import warnings
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 __all__ = ["Telnet"]
 

--- a/telnetlib/telnetlib/__init__.py
+++ b/telnetlib/telnetlib/__init__.py
@@ -39,7 +39,8 @@ import selectors
 from time import monotonic as _time
 import warnings
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 __all__ = ["Telnet"]
 

--- a/uu/uu/__init__.py
+++ b/uu/uu/__init__.py
@@ -35,7 +35,8 @@ import os
 import sys
 import warnings
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 __all__ = ["Error", "encode", "decode"]
 

--- a/uu/uu/__init__.py
+++ b/uu/uu/__init__.py
@@ -35,8 +35,8 @@ import os
 import sys
 import warnings
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 __all__ = ["Error", "encode", "decode"]
 

--- a/xdrlib/xdrlib/__init__.py
+++ b/xdrlib/xdrlib/__init__.py
@@ -9,8 +9,8 @@ from io import BytesIO
 from functools import wraps
 import warnings
 
-# python-deadlib: Remove deprecation warning
-# warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
 
 __all__ = ["Error", "Packer", "Unpacker", "ConversionError"]
 

--- a/xdrlib/xdrlib/__init__.py
+++ b/xdrlib/xdrlib/__init__.py
@@ -9,7 +9,8 @@ from io import BytesIO
 from functools import wraps
 import warnings
 
-warnings._deprecated(__name__, remove=(3, 13))
+# python-deadlib: Remove deprecation warning
+# warnings._deprecated(__name__, remove=(3, 13))
 
 __all__ = ["Error", "Packer", "Unpacker", "ConversionError"]
 


### PR DESCRIPTION
To avoid having to go through every single module individually and fix them up, I decided to bulk change the ones which are simple to do.

I ran a global find & replace to comment out the deprecation notice and then ran the tests.  The following ones passed with no further changes required:

* cgi
* cgitb
* chunk
* nntplib
* pipes
* telnetlib
* uu
* xdrlib