### PR TITLE
Increase stacklevel for DeprecationWarning

### DIFF
--- a/aifc/aifc/__init__.py
+++ b/aifc/aifc/__init__.py
@@ -142,7 +142,12 @@ __all__ = ["Error", "open"]
 
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 class Error(Exception):
     pass

--- a/aifc/aifc/__init__.py
+++ b/aifc/aifc/__init__.py
@@ -146,7 +146,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 class Error(Exception):

--- a/asynchat/asynchat/__init__.py
+++ b/asynchat/asynchat/__init__.py
@@ -51,10 +51,12 @@ from collections import deque
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-_DEPRECATION_MSG = (f'The {__name__} module was removed in '
-                    'Python 3.12. The recommended replacement is asyncio. '
-                    'Please be aware that you are currently NOT using standard "{__name__}", but instead a separately installed "standard-{__name__}".')
-warnings.warn(_DEPRECATION_MSG, DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.12. The recommended replacement is asyncio. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 class async_chat(asyncore.dispatcher):

--- a/asynchat/asynchat/__init__.py
+++ b/asynchat/asynchat/__init__.py
@@ -55,7 +55,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.12. The recommended replacement is asyncio. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/asyncore/asyncore/__init__.py
+++ b/asyncore/asyncore/__init__.py
@@ -62,7 +62,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.12. The recommended replacement is asyncio. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/asyncore/asyncore/__init__.py
+++ b/asyncore/asyncore/__init__.py
@@ -58,10 +58,12 @@ from errno import EALREADY, EINPROGRESS, EWOULDBLOCK, ECONNRESET, EINVAL, \
      errorcode
 
 # python-deadlib: Replace deprecation warning not to raise exception
-_DEPRECATION_MSG = (f'The {__name__} module was removed in '
-                    'Python 3.12. The recommended replacement is asyncio. '
-                    'Please be aware that you are currently NOT using standard "{__name__}", but instead a separately installed "standard-{__name__}".')
-warnings.warn(_DEPRECATION_MSG, DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.12. The recommended replacement is asyncio. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 _DISCONNECTED = frozenset({ECONNRESET, ENOTCONN, ESHUTDOWN, ECONNABORTED, EPIPE,

--- a/cgi/cgi/__init__.py
+++ b/cgi/cgi/__init__.py
@@ -59,7 +59,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 # Logging support

--- a/cgi/cgi/__init__.py
+++ b/cgi/cgi/__init__.py
@@ -54,9 +54,13 @@ __all__ = ["MiniFieldStorage", "FieldStorage", "parse", "parse_multipart",
            "print_environ_usage"]
 
 
-# python-deadlib: Remove deprecation warning
-# # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+# python-deadlib: Replace deprecation warning not to raise exception
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 # Logging support
 # ===============

--- a/cgitb/cgitb/__init__.py
+++ b/cgitb/cgitb/__init__.py
@@ -39,7 +39,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/cgitb/cgitb/__init__.py
+++ b/cgitb/cgitb/__init__.py
@@ -35,7 +35,12 @@ import warnings
 from html import escape as html_escape
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 def reset():

--- a/chunk/chunk/__init__.py
+++ b/chunk/chunk/__init__.py
@@ -55,7 +55,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 class Chunk:

--- a/chunk/chunk/__init__.py
+++ b/chunk/chunk/__init__.py
@@ -51,7 +51,12 @@ default is 1, i.e. aligned.
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 class Chunk:
     def __init__(self, file, align=True, bigendian=True, inclheader=False):

--- a/crypt/crypt/__init__.py
+++ b/crypt/crypt/__init__.py
@@ -18,7 +18,12 @@ from collections import namedtuple as _namedtuple
 
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 _saltchars = _string.ascii_letters + _string.digits + './'

--- a/crypt/crypt/__init__.py
+++ b/crypt/crypt/__init__.py
@@ -22,7 +22,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/imghdr/imghdr/__init__.py
+++ b/imghdr/imghdr/__init__.py
@@ -7,7 +7,12 @@ __all__ = ["what"]
 
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 #-------------------------#

--- a/imghdr/imghdr/__init__.py
+++ b/imghdr/imghdr/__init__.py
@@ -11,7 +11,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/mailcap/mailcap/__init__.py
+++ b/mailcap/mailcap/__init__.py
@@ -12,7 +12,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. See the mimetypes module for an alternative. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/mailcap/mailcap/__init__.py
+++ b/mailcap/mailcap/__init__.py
@@ -8,11 +8,12 @@ __all__ = ["getcaps","findmatch"]
 
 
 # python-deadlib: Replace deprecation warning not to raise exception
-_DEPRECATION_MSG = ('The {__name__} module was removed in '
-                    'Python 3.13. See the mimetypes module for an '
-                    'alternative.'
-                    'Please be aware that you are currently NOT using standard "{__name__}", but instead a separately installed "standard-{__name__}".')
-warnings.warn(_DEPRECATION_MSG, DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. See the mimetypes module for an alternative. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 def lineno_sort_key(entry):

--- a/nntplib/nntplib/__init__.py
+++ b/nntplib/nntplib/__init__.py
@@ -87,7 +87,12 @@ __all__ = ["NNTP",
            ]
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 # maximal line length when calling readline(). This is to prevent
 # reading arbitrary length lines. RFC 3977 limits NNTP line length to

--- a/nntplib/nntplib/__init__.py
+++ b/nntplib/nntplib/__init__.py
@@ -91,7 +91,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 # maximal line length when calling readline(). This is to prevent

--- a/pipes/pipes/__init__.py
+++ b/pipes/pipes/__init__.py
@@ -66,7 +66,12 @@ import warnings
 from shlex import quote
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 __all__ = ["Template"]
 

--- a/pipes/pipes/__init__.py
+++ b/pipes/pipes/__init__.py
@@ -70,7 +70,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 __all__ = ["Template"]

--- a/smtpd/smtpd/__init__.py
+++ b/smtpd/smtpd/__init__.py
@@ -90,7 +90,7 @@ warn(
     "aiosmtpd (https://aiosmtpd.readthedocs.io/) for the recommended replacement."
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/smtpd/smtpd/__init__.py
+++ b/smtpd/smtpd/__init__.py
@@ -84,12 +84,14 @@ __all__ = [
     "SMTPChannel", "SMTPServer", "DebuggingServer", "PureProxy",
 ]
 
-_DEPRECATION_MSG = ('The {__name__} module was '
-                    'removed in Python 3.12.  Please see aiosmtpd '
-                    '(https://aiosmtpd.readthedocs.io/) for the recommended '
-                    'replacement. '
-                    'Please be aware that you are currently NOT using standard "{__name__}", but instead a separately installed "standard-{__name__}".')
-warn(_DEPRECATION_MSG, DeprecationWarning)
+# python-deadlib: Replace deprecation warning not to raise exception
+warn(
+    f"{__name__} was removed in Python 3.12. Please see "
+    "aiosmtpd (https://aiosmtpd.readthedocs.io/) for the recommended replacement."
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 # These are imported after the above warning so that users get the correct

--- a/sndhdr/sndhdr/__init__.py
+++ b/sndhdr/sndhdr/__init__.py
@@ -34,7 +34,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 # The file structure is top-down except that the test program and its

--- a/sndhdr/sndhdr/__init__.py
+++ b/sndhdr/sndhdr/__init__.py
@@ -30,7 +30,12 @@ explicitly given directories.
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 # The file structure is top-down except that the test program and its
 # subroutine come last.

--- a/sunau/sunau/__init__.py
+++ b/sunau/sunau/__init__.py
@@ -107,7 +107,12 @@ from collections import namedtuple
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 
 _sunau_params = namedtuple('_sunau_params',

--- a/sunau/sunau/__init__.py
+++ b/sunau/sunau/__init__.py
@@ -111,7 +111,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 

--- a/telnetlib/telnetlib/__init__.py
+++ b/telnetlib/telnetlib/__init__.py
@@ -40,7 +40,12 @@ from time import monotonic as _time
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 __all__ = ["Telnet"]
 

--- a/telnetlib/telnetlib/__init__.py
+++ b/telnetlib/telnetlib/__init__.py
@@ -44,7 +44,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 __all__ = ["Telnet"]

--- a/uu/uu/__init__.py
+++ b/uu/uu/__init__.py
@@ -40,7 +40,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 __all__ = ["Error", "encode", "decode"]

--- a/uu/uu/__init__.py
+++ b/uu/uu/__init__.py
@@ -36,7 +36,12 @@ import sys
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 __all__ = ["Error", "encode", "decode"]
 

--- a/xdrlib/xdrlib/__init__.py
+++ b/xdrlib/xdrlib/__init__.py
@@ -14,7 +14,7 @@ warnings.warn(
     f"{__name__} was removed in Python 3.13. "
     f"Please be aware that you are currently NOT using standard '{__name__}', "
     f"but instead a separately installed 'standard-{__name__}'.",
-    DeprecationWarning,
+    DeprecationWarning, stacklevel=2
 )
 
 __all__ = ["Error", "Packer", "Unpacker", "ConversionError"]

--- a/xdrlib/xdrlib/__init__.py
+++ b/xdrlib/xdrlib/__init__.py
@@ -10,7 +10,12 @@ from functools import wraps
 import warnings
 
 # python-deadlib: Replace deprecation warning not to raise exception
-warnings.warn(f"{__name__} was removed in Python 3.13. Please be aware that you are currently NOT using standard '{__name__}', but instead a separately installed 'standard-{__name__}'.", DeprecationWarning)
+warnings.warn(
+    f"{__name__} was removed in Python 3.13. "
+    f"Please be aware that you are currently NOT using standard '{__name__}', "
+    f"but instead a separately installed 'standard-{__name__}'.",
+    DeprecationWarning,
+)
 
 __all__ = ["Error", "Packer", "Unpacker", "ConversionError"]
 


### PR DESCRIPTION
Increase the `stacklevel` to `2`. The DeprecationWarning should be emitted at the import location.