### PR TITLE
Use SPDX license identifier

### DIFF
--- a/aifc/pyproject.toml
+++ b/aifc/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/asynchat/pyproject.toml
+++ b/asynchat/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/asynchat/pyproject.toml
+++ b/asynchat/pyproject.toml
@@ -24,5 +24,5 @@ find = {include = ["asynchat*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/asyncore/pyproject.toml
+++ b/asyncore/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["asyncore*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/asyncore/pyproject.toml
+++ b/asyncore/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/cgi/pyproject.toml
+++ b/cgi/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/cgi/pyproject.toml
+++ b/cgi/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["cgi*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/cgitb/pyproject.toml
+++ b/cgitb/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["cgitb*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/cgitb/pyproject.toml
+++ b/cgitb/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/chunk/pyproject.toml
+++ b/chunk/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["chunk*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/chunk/pyproject.toml
+++ b/chunk/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/crypt/pyproject.toml
+++ b/crypt/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["crypt*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/crypt/pyproject.toml
+++ b/crypt/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/distutils/pyproject.toml
+++ b/distutils/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["distutils*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/distutils/pyproject.toml
+++ b/distutils/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/imghdr/pyproject.toml
+++ b/imghdr/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/imghdr/pyproject.toml
+++ b/imghdr/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["imghdr*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/mailcap/pyproject.toml
+++ b/mailcap/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/mailcap/pyproject.toml
+++ b/mailcap/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["mailcap*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/nntplib/pyproject.toml
+++ b/nntplib/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["nntplib*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/nntplib/pyproject.toml
+++ b/nntplib/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/pipes/pyproject.toml
+++ b/pipes/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/pipes/pyproject.toml
+++ b/pipes/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["pipes*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/smtpd/pyproject.toml
+++ b/smtpd/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/smtpd/pyproject.toml
+++ b/smtpd/pyproject.toml
@@ -25,5 +25,5 @@ find = {include = ["smtpd*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/sndhdr/pyproject.toml
+++ b/sndhdr/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/sndhdr/pyproject.toml
+++ b/sndhdr/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["sndhdr*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/sunau/pyproject.toml
+++ b/sunau/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/sunau/pyproject.toml
+++ b/sunau/pyproject.toml
@@ -24,5 +24,5 @@ find = {include = ["sunau*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/telnetlib/pyproject.toml
+++ b/telnetlib/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/telnetlib/pyproject.toml
+++ b/telnetlib/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["telnetlib*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["{name}*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/uu/pyproject.toml
+++ b/uu/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["uu*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/uu/pyproject.toml
+++ b/uu/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",

--- a/xdrlib/pyproject.toml
+++ b/xdrlib/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["xdrlib*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"

--- a/xdrlib/pyproject.toml
+++ b/xdrlib/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Python Developers", email = "python-deadlib@youknowone.org" }
 ]
 readme = "README.rst"
-license = {name = "PSF", file = "LICENSE"}
+license = { text = "PSF-2.0" }
 classifiers = [
     "License :: OSI Approved :: Python Software Foundation License",
     "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
The pyproject `license` key should be a table with either the `text` or the `file` key. Use `text` with the correct SPDX license identifier: `PSF-2.0`. https://spdx.org/licenses/PSF-2.0.html

With recent setuptools versions, the license file is automatically included in the sdist and wheel. Updated the min version to the latest release.

<details>
<summary>The project metadata after this change (e.g. for aifc)</summary>

```
Metadata-Version: 2.1
Name: standard-aifc
Version: 3.12.2
Summary: Standard library aifc redistribution. "dead battery".
Author-email: Python Developers <python-deadlib@youknowone.org>
License: PSF-2.0
Project-URL: Homepage, https://github.com/youknowone/python-deadlib
Keywords: stdlib
Classifier: License :: OSI Approved :: Python Software Foundation License
Classifier: Topic :: Software Development :: Libraries
Classifier: Programming Language :: Python :: 3
Description-Content-Type: text/x-rst
License-File: LICENSE
Requires-Dist: chunkmuncher>=0.0.2
Requires-Dist: audioop-lts; python_version >= "3.13"

Dead battery redistribution
===========================

Python is moving forward! Python finally started to remove dead batteries.
For more information, see `PEP 594 <https://peps.python.org/pep-0594/>`_.

If your project depends on a module that has been removed from the standard,
here is the redistribution of the dead batteries.
```
</details>