### PR TITLE
Revert aifc changes to use chunkmuncher and add standard-chunk

### DIFF
--- a/aifc/aifc/__init__.py
+++ b/aifc/aifc/__init__.py
@@ -260,11 +260,9 @@ def _write_float(f, x):
     _write_ulong(f, himant)
     _write_ulong(f, lomant)
 
-# python-deadlib: replace removed library chunk with third party library
-# with warnings.catch_warnings():
-#     warnings.simplefilter("ignore", DeprecationWarning)
-#     from chunk import Chunk
-from chunkmuncher.chunk import Chunk
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from chunk import Chunk
 from collections import namedtuple
 
 _aifc_params = namedtuple('_aifc_params',

--- a/aifc/pyproject.toml
+++ b/aifc/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "chunkmuncher>=0.0.2", # chunkmuncher sits of different namespace to python core chunk module, so can install it on all versions
+    "standard-chunk; python_version >= '3.13'", # chunk uses same namespace as python core module, so only install it on versions where it's not included
     "audioop-lts; python_version >= '3.13'", # audioop uses same namespace as python core module, so only install it on versions where it's not included
 ]
 


### PR DESCRIPTION
@lucas42 I thought chunk is a c module, but it wasn't. Keeping it to use original chunk looks fine for aifc, right?