### PR TITLE
Create dummy chunk tests folder

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
         id: get-folders
         run: |
           pip install -U pip -r requirements_test.txt
-          FOLDERS=$(python scripts/helper.py list-test-folders --exclude distutils)
+          FOLDERS=$(python scripts/helper.py list-test-folders --exclude distutils --exclude chunk)
           echo "folders: ${FOLDERS}"
           echo "folders=${FOLDERS}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The helper script looks for `tests` folders to determine which packages to build. That worked as all packages had a `tests` folder. Except for `chunk`.