### PR TITLE
Lower setuptools version to 69.0

### DIFF
--- a/mailcap/pyproject.toml
+++ b/mailcap/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["mailcap*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fedora is using setuptools-69