### PR TITLE
Add tests fixture

### DIFF
--- a/mailcap/pyproject.toml
+++ b/mailcap/pyproject.toml
@@ -15,7 +15,10 @@ classifiers = [
 ]
 
 [tool.setuptools.packages]
-find = {include = ["mailcap*"]}
+find = {include = ["mailcap*", "tests*"]}
+
+[tool.setuptools.package-data]
+tests = ["*.txt"]
 
 [project.urls]
 "Homepage" = "https://github.com/youknowone/python-deadlib"


### PR DESCRIPTION
This will include the tests fixture in the distribution.

`tests/test_mailcap.py` is already part of the distribution but `tests/mailcap.txt` is missing.