### PR TITLE
Downgrade setuptools to >=69.0

### DIFF
--- a/asynchat/pyproject.toml
+++ b/asynchat/pyproject.toml
@@ -24,5 +24,5 @@ find = {include = ["asynchat*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/asyncore/pyproject.toml
+++ b/asyncore/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["asyncore*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/cgi/pyproject.toml
+++ b/cgi/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["cgi*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/cgitb/pyproject.toml
+++ b/cgitb/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["cgitb*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/chunk/pyproject.toml
+++ b/chunk/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["chunk*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/crypt/pyproject.toml
+++ b/crypt/pyproject.toml
@@ -24,5 +24,5 @@ find = {include = ["crypt*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/distutils/pyproject.toml
+++ b/distutils/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["distutils*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/imghdr/pyproject.toml
+++ b/imghdr/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["imghdr*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/mailcap/pyproject.toml
+++ b/mailcap/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["mailcap*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/nntplib/pyproject.toml
+++ b/nntplib/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["nntplib*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/pipes/pyproject.toml
+++ b/pipes/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["pipes*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/smtpd/pyproject.toml
+++ b/smtpd/pyproject.toml
@@ -25,5 +25,5 @@ find = {include = ["smtpd*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/sndhdr/pyproject.toml
+++ b/sndhdr/pyproject.toml
@@ -24,5 +24,5 @@ find = {include = ["sndhdr*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/sunau/pyproject.toml
+++ b/sunau/pyproject.toml
@@ -24,5 +24,5 @@ find = {include = ["sunau*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/telnetlib/pyproject.toml
+++ b/telnetlib/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["telnetlib*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["{name}*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/uu/pyproject.toml
+++ b/uu/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["uu*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"

--- a/xdrlib/pyproject.toml
+++ b/xdrlib/pyproject.toml
@@ -21,5 +21,5 @@ find = {include = ["xdrlib*"]}
 "Homepage" = "https://github.com/youknowone/python-deadlib"
 
 [build-system]
-requires = ["setuptools>=75.0"]
+requires = ["setuptools>=69.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Replaces #42

Tested building the sdist and wheel with setuptools `69.0.0`. It seems to work fine. For the missing `bdist_wheel` command,  `wheel` is automatically installed during the build.

/CC @meeuw @youknowone