### PR TITLE
macOS 12 has been removed from GitHub Actions

### DIFF
--- a/.github/workflows/_crypt.yml
+++ b/.github/workflows/_crypt.yml
@@ -97,9 +97,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
-          - runner: macos-14
+          - runner: macos-15
             target: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/youknowone/python-deadlib/actions/runs/12011606910/job/33896039857?pr=46

The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15. For more details, see https://github.com/actions/runner-images/issues/10721
